### PR TITLE
Remove ansible dependency

### DIFF
--- a/napalm_srl/srl.py
+++ b/napalm_srl/srl.py
@@ -31,7 +31,6 @@ import grpc
 from google.protobuf import json_format
 import ast
 from napalm_srl import gnmi_pb2, jsondiff
-from ansible.errors import AnsibleConnectionFailure
 import tempfile
 
 from napalm.base import NetworkDriver
@@ -2549,11 +2548,9 @@ class SRLAPI(object):
         Returns:
             File content
         Raises:
-            AnsibleConnectionFailure: file does not exist or read excpetions
+            ConnectionException: file does not exist or read excpetions
         """
-        path = "/tmp"
-        if not path:
-            path = "/etc/ssl:/etc/ssl/certs:/etc/ca-certificates"
+        path = "/etc/ssl:/etc/ssl/certs:/etc/ca-certificates"
 
         if filename:
             if filename.startswith("~"):
@@ -2568,11 +2565,11 @@ class SRLAPI(object):
                     with open(filename, "rb") as f:
                         return f.read()
                 except Exception as exc:
-                    raise AnsibleConnectionFailure(
+                    raise ConnectionException(
                         "Failed to read cert/keys file %s: %s" % (filename, exc)
                     )
             else:
-                raise AnsibleConnectionFailure(
+                raise ConnectionException(
                     "Cert/keys file %s does not exist" % filename
                 )
         return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 napalm>=2.0.0
-ansible~=2.9.12
 pip>=20.1.1
 pytest>=5.4.3
 setuptools>=47.3.1


### PR DESCRIPTION
- remove ansible dependency
- cleanup path logic

This works for me and allows me to use much more recent ansible when this driver is used together with https://github.com/napalm-automation/napalm-ansible

Fixes #14 