### PR TITLE
Limit version of protobuf

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ ncclient>=0.6.7
 xmltodict>=0.12.0
 dictdiffer>=0.8.1
 grpcio
-protobuf
+protobuf<4


### PR DESCRIPTION
Limit version of protobuf - with newer protobuf version napalm fails to load this driver.
```
>>> import napalm
>>> napalm.get_network_driver('srl')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/srv/conda/envs/nca_playbooks_env_uat/lib/python3.10/site-packages/napalm/base/__init__.py", line 88, in get_network_driver
    module = importlib.import_module(module_name)
  File "/srv/conda/envs/nca_playbooks_env_uat/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/srv/conda/envs/nca_playbooks_env_uat/lib/python3.10/site-packages/napalm_srl/__init__.py", line 16, in <module>
    from napalm_srl.srl import NokiaSRLDriver  # noqa
  File "/srv/conda/envs/nca_playbooks_env_uat/lib/python3.10/site-packages/napalm_srl/srl.py", line 33, in <module>
    from napalm_srl import gnmi_pb2, jsondiff
  File "/srv/conda/envs/nca_playbooks_env_uat/lib/python3.10/site-packages/napalm_srl/gnmi_pb2.py", line 39, in <module>
    _descriptor.EnumValueDescriptor(
  File "/srv/conda/envs/nca_playbooks_env_uat/lib/python3.10/site-packages/google/protobuf/descriptor.py", line 755, in __new__
    _message.Message._CheckCalledFromGeneratedFile()
TypeError: Descriptors cannot not be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).

More information: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
>>>
```
I know that fix for newer protobuf would be better, but I don't have enough experience with it so at least fixing the requirements.
Any advise on how to solve this better is welcomed.