### PR TITLE
Add option to get running config in CLI format

### DIFF
--- a/napalm_srl/srl.py
+++ b/napalm_srl/srl.py
@@ -65,6 +65,7 @@ class NokiaSRLDriver(NetworkDriver):
 
         self._stub = None
         self._channel = None
+        self.optional_args = optional_args
 
         self.device = SRLAPI(hostname, username, password, timeout=60, optional_args=optional_args)
 
@@ -1703,22 +1704,33 @@ class NokiaSRLDriver(NetworkDriver):
                     "startup": ""
                 }
 
-            running = self.device._gnmiGet("", {"/"}, "CONFIG")
-            if sanitized:
-                if "srl_nokia-system:system" in running:
-                    if "srl_nokia-aaa:aaa" in running["srl_nokia-system:system"]:
-                        del running["srl_nokia-system:system"]["srl_nokia-aaa:aaa"]
-                    if "srl_nokia-tls:tls" in running["srl_nokia-system:system"]:
-                        del running["srl_nokia-system:system"]["srl_nokia-tls:tls"]
+            if self.optional_args.get('running_format') == 'cli':
+                cmds = [
+                  "info flat",
+                ]
+                output = self.device._jsonrpcRunCli(cmds)
+                running_config = self._return_result(output)
+                if sanitized:
+                    raise NotImplementedError(
+                        "sanitized=True is not implemented with CLI format")
+            else:
+                running = self.device._gnmiGet("", {"/"}, "CONFIG")
+                if sanitized:
+                    if "srl_nokia-system:system" in running:
+                        if "srl_nokia-aaa:aaa" in running["srl_nokia-system:system"]:
+                            del running["srl_nokia-system:system"]["srl_nokia-aaa:aaa"]
+                        if "srl_nokia-tls:tls" in running["srl_nokia-system:system"]:
+                            del running["srl_nokia-system:system"]["srl_nokia-tls:tls"]
+                running_config = json.dumps(running)
             if retrieve == 'all':
                 return {
-                    "running": json.dumps(running),
+                    "running": running_config,
                     "candidate": "",
                     "startup": ""
                 }
             if retrieve == 'running':
                 return {
-                    "running": json.dumps(running),
+                    "running": running_config,
                     "candidate": "",
                     "startup": ""
                 }


### PR DESCRIPTION
Add option to get running config in CLI format - adding optional arg `running_format` and if value is `cli` the `get_config()` returns the config in flat cli format.