### PR TITLE
Add CI/CD test cases using Containerlab

### DIFF
--- a/.clab/ci-topology.yml
+++ b/.clab/ci-topology.yml
@@ -1,0 +1,14 @@
+---
+name: napalm-ci_cd
+
+topology:
+  kinds:
+    srl:
+      image: ghcr.io/nokia/srlinux:latest # Could pick specific version
+  nodes:
+    # TODO multiple node flavors like ixrd2, ixrd3, ixrd2l, etc.
+    srl:
+      kind: srl
+      mgmt_ipv4: 172.20.20.16
+      mgmt_ipv6: 2001:172:20:20::16
+      # startup-config: startup-config.cmd # Start with basic Containerlab config

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,3 +34,34 @@ jobs:
     - name: Run tests
       run: |
         pytest
+
+  clab-ci-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 1
+      matrix:
+        python-version: ["3.10"]
+    needs:
+    - tests # Will only run if unit tests pass
+    steps:
+    - uses: actions/checkout@v3
+
+    # TODO ideally this would reuse the work from 'tests'
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    # - name: pull srlinux image
+    #   run: docker pull ghcr.io/nokia/srlinux:latest
+    - name: install latest clab
+      run: bash -c "$(curl -sL https://get.containerlab.dev)" # -- -v 0.36.1
+    - name: start clab ci topo
+      run: make deploy-clab-ci
+    - name: tests
+      run: make run-tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,5 +63,5 @@ jobs:
       run: bash -c "$(curl -sL https://get.containerlab.dev)" # -- -v 0.36.1
     - name: start clab ci topo
       run: make deploy-clab-ci
-    - name: tests
+    - name: Run all CI tests under test/ci
       run: make run-tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies and the library itself
+    - name: Install dependencies and the NAPALM driver library itself
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,10 +52,10 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies
+    - name: Install dependencies and the library itself
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        pip install -r requirements.txt .
 
     # - name: pull srlinux image
     #   run: docker pull ghcr.io/nokia/srlinux:latest

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+# CI/CD tasks
+
+.DEFAULT_GOAL := help
+
+.PHONY: help deploy-clab-ci destroy-clab-ci run-tests
+
+TESTS := $(shell find test/ci -name '*.py')
+
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+deploy-clab-ci: ## Deploy "ci" test topology
+	cd .clab && sudo clab deploy -t ci-topology.yml
+
+destroy-clab-ci: ## Destroy "ci" test topology
+	cd .clab && sudo clab destroy -t ci-topology.yml
+
+run-tests: $(TESTS) ## Run all CI tests under test/ci
+	python3 $<

--- a/test/ci/load_commit_rollback.py
+++ b/test/ci/load_commit_rollback.py
@@ -25,7 +25,7 @@ device.commit_config()
 
 # get config -> check that description is set
 config = device.get_config()
-print( config )
+print( config["running"]["srl_nokia-interfaces:interface"][0] )
 assert( config["running"]["srl_nokia-interfaces:interface"][0]["description"] == DESC )
 
 reply = device.rollback()

--- a/test/ci/load_commit_rollback.py
+++ b/test/ci/load_commit_rollback.py
@@ -1,0 +1,42 @@
+#!/usr/bin/python3
+
+from napalm import get_network_driver
+import json, time, sys
+from datetime import datetime
+
+driver = get_network_driver("srl")
+optional_args = {
+    "gnmi_port": 57400,
+    "jsonrpc_port": 443,
+    "insecure": True,
+    "encoding": "JSON_IETF"
+}
+device = driver("clab-napalm-ci_cd-srl", "admin", "NokiaSrl1!", 10, optional_args)
+device.open()
+#print(device.get_facts())
+#print(device.get_optics())
+now = datetime.now().strftime("%H:%M:%S")
+DESC = f"Time {now}"
+cfg = f"""
+set /interface ethernet-1/1 description "{DESC}"
+"""
+reply = device.load_merge_candidate(config=cfg) # CLI format
+print( reply )
+assert( reply.result == True )
+reply2 = device.commit_config()
+print( reply2 )
+
+# get config -> check that description is set
+config = device.get_config()
+print( config )
+assert( config["interface"]["ethernet-1/1"]["description"] == DESC )
+
+reply3 = device.rollback()
+print( reply3 )
+
+config2 = device.get_config()
+assert( config["interface"]["ethernet-1/1"]["description"] != DESC )
+
+device.close()
+
+sys.exit(0) # Success

--- a/test/ci/load_commit_rollback.py
+++ b/test/ci/load_commit_rollback.py
@@ -34,7 +34,7 @@ print( reply )
 
 config2 = device.get_config()
 parsed2 = json.loads(config2["running"])
-assert( parsed2["srl_nokia-interfaces:interface"][0]["description"] != DESC )
+assert( "description" not in parsed2["srl_nokia-interfaces:interface"][0] )
 
 device.close()
 

--- a/test/ci/load_commit_rollback.py
+++ b/test/ci/load_commit_rollback.py
@@ -20,19 +20,16 @@ DESC = f"Time {now}"
 cfg = f"""
 set /interface ethernet-1/1 description "{DESC}"
 """
-reply = device.load_merge_candidate(config=cfg) # CLI format
-print( reply )
-assert( reply.result == True )
-reply2 = device.commit_config()
-print( reply2 )
+device.load_merge_candidate(config=cfg) # CLI format
+device.commit_config()
 
 # get config -> check that description is set
 config = device.get_config()
 print( config )
 assert( config["interface"]["ethernet-1/1"]["description"] == DESC )
 
-reply3 = device.rollback()
-print( reply3 )
+reply = device.rollback()
+print( reply )
 
 config2 = device.get_config()
 assert( config["interface"]["ethernet-1/1"]["description"] != DESC )

--- a/test/ci/load_commit_rollback.py
+++ b/test/ci/load_commit_rollback.py
@@ -25,14 +25,16 @@ device.commit_config()
 
 # get config -> check that description is set
 config = device.get_config()
-print( config["running"]["srl_nokia-interfaces:interface"][0] )
-assert( config["running"]["srl_nokia-interfaces:interface"][0]["description"] == DESC )
+parsed = json.loads(config["running"])
+print( json.dumps(parsed["srl_nokia-interfaces:interface"],indent=2) )
+assert( parsed["srl_nokia-interfaces:interface"][0]["description"] == DESC )
 
 reply = device.rollback()
 print( reply )
 
 config2 = device.get_config()
-assert( config["running"]["srl_nokia-interfaces:interface"][0]["description"] != DESC )
+parsed2 = json.loads(config2["running"])
+assert( parsed2["srl_nokia-interfaces:interface"][0]["description"] != DESC )
 
 device.close()
 

--- a/test/ci/load_commit_rollback.py
+++ b/test/ci/load_commit_rollback.py
@@ -26,13 +26,13 @@ device.commit_config()
 # get config -> check that description is set
 config = device.get_config()
 print( config )
-assert( config["interface"]["ethernet-1/1"]["description"] == DESC )
+assert( config["running"]["srl_nokia-interfaces:interface"][0]["description"] == DESC )
 
 reply = device.rollback()
 print( reply )
 
 config2 = device.get_config()
-assert( config["interface"]["ethernet-1/1"]["description"] != DESC )
+assert( config["running"]["srl_nokia-interfaces:interface"][0]["description"] != DESC )
 
 device.close()
 

--- a/test/ci/test.py
+++ b/test/ci/test.py
@@ -1,0 +1,5 @@
+import sys
+
+print( "test.py executed -> emulating failure" )
+
+sys.exit(1)

--- a/test/ci/test.py
+++ b/test/ci/test.py
@@ -1,5 +1,0 @@
-import sys
-
-print( "test.py executed -> emulating failure" )
-
-sys.exit(1)


### PR DESCRIPTION
This PR adds a capability to run CI/CD test cases against a virtual topology created using Containerlab.

It currently contains only 1 test: Configuration merge, commit and rollback. Additional (regression) tests can be added, and all will be executed (in alphabetical order)