### PR TITLE
Fix is_alive to be consistent with close()

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,4 +4,8 @@ repos:
   rev: 'v0.0.245'
   hooks:
     - id: ruff
-      args: [--fix, --exit-non-zero-on-fix]
+      args: 
+      - --fix
+      - --exit-non-zero-on-fix 
+      - --ignore 
+      - E501

--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,4 @@ destroy-clab-ci: ## Destroy "ci" test topology
 	cd .clab && sudo clab destroy -t ci-topology.yml
 
 run-tests: $(TESTS) ## Run all CI tests under test/ci
-	python3 $<
+	PYTHONPATH="." python3 $<

--- a/napalm_srl/srl.py
+++ b/napalm_srl/srl.py
@@ -2012,14 +2012,15 @@ class NokiaSRLDriver(NetworkDriver):
             logging.error("Error occurred : {}".format(e))
 
     def is_alive(self):
-        try:
-            output = self.device._jsonrpcRunCli(["date"])
-            if "result" in output:
-                return {"is_alive": True}
-            else:
-                return {"is_alive": False}
-        except Exception:
-            return {"is_alive": False}
+        alive = False
+        if self._channel:
+            try:
+                output = self.device._jsonrpcRunCli(["date"])
+                if "result" in output:
+                    alive = True
+            except Exception as e:
+                logging.error( f"Exception in is_alive: {e} -> returning False" )
+        return { "is_alive": alive }
 
     def traceroute(self, destination, source="", ttl=255, timeout=2, vrf=""):
         try:

--- a/test/ci/load_commit_rollback.py
+++ b/test/ci/load_commit_rollback.py
@@ -5,6 +5,9 @@ import sys
 from napalm import get_network_driver
 from datetime import datetime
 
+import logging
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+
 driver = get_network_driver("srl")
 optional_args = {
     "gnmi_port": 57400,
@@ -55,6 +58,6 @@ assert( parsed3["srl_nokia-interfaces:interface"][0]["description"] == DESC )
 device.close()
 
 # Regression: check that is_alive returns false
-assert( not device.is_alive() )
+assert( not device.is_alive()['is_alive'] )
 
 sys.exit(0) # Success

--- a/test/ci/load_commit_rollback.py
+++ b/test/ci/load_commit_rollback.py
@@ -25,11 +25,11 @@ device.load_merge_candidate(config=cfg) # CLI format
 device.commit_config()
 
 cfg2 = {
- "interfaces": [
+ "interface": [
   { "name": "ethernet-1/1", "description": f"{DESC} using JSON" }
  ]
 }
-device.load_merge_candidate(config=json.dunps(cfg2)) # JSON format
+device.load_merge_candidate(config=json.dumps(cfg2)) # JSON format
 device.commit_config()
 
 # get config -> check that description is set

--- a/test/ci/load_commit_rollback.py
+++ b/test/ci/load_commit_rollback.py
@@ -24,6 +24,12 @@ set /interface ethernet-1/1 description "{DESC}"
 device.load_merge_candidate(config=cfg) # CLI format
 device.commit_config()
 
+# get config -> check that description is set
+config = device.get_config()
+parsed = json.loads(config["running"])
+print( json.dumps(parsed["srl_nokia-interfaces:interface"],indent=2) )
+assert( parsed["srl_nokia-interfaces:interface"][0]["description"] == DESC )
+
 cfg2 = {
  "interface": [
   { "name": "ethernet-1/1", "description": f"{DESC} using JSON" }
@@ -33,17 +39,18 @@ device.load_merge_candidate(config=json.dumps(cfg2)) # JSON format
 device.commit_config()
 
 # get config -> check that description is set
-config = device.get_config()
-parsed = json.loads(config["running"])
-print( json.dumps(parsed["srl_nokia-interfaces:interface"],indent=2) )
-assert( parsed["srl_nokia-interfaces:interface"][0]["description"] == DESC )
+config2 = device.get_config()
+parsed2 = json.loads(config2["running"])
+print( json.dumps(parsed2["srl_nokia-interfaces:interface"],indent=2) )
+assert( parsed2["srl_nokia-interfaces:interface"][0]["description"] == cfg2["interface"][0]["description"] )
 
+# Revert changes in most recent commit_config
 reply = device.rollback()
 print( reply )
 
-config2 = device.get_config()
-parsed2 = json.loads(config2["running"])
-assert( "description" not in parsed2["srl_nokia-interfaces:interface"][0] )
+config3 = device.get_config()
+parsed3 = json.loads(config3["running"])
+assert( parsed3["srl_nokia-interfaces:interface"][0]["description"] == DESC )
 
 device.close()
 

--- a/test/ci/load_commit_rollback.py
+++ b/test/ci/load_commit_rollback.py
@@ -47,4 +47,7 @@ assert( "description" not in parsed2["srl_nokia-interfaces:interface"][0] )
 
 device.close()
 
+# Regression: check that is_alive returns false
+assert( not device.is_alive() )
+
 sys.exit(0) # Success

--- a/test/unit/mocked_data/test_is_alive/normal/expected_result.json
+++ b/test/unit/mocked_data/test_is_alive/normal/expected_result.json
@@ -1,1 +1,1 @@
-{"is_alive":true}
+{"is_alive":false}


### PR DESCRIPTION
The Napalm framework checks is_alive() upon exit, and calls close() if it returns True

The apparent expectation is for is_alive() to return False before open() and after close()