### PR TITLE
Fix get_interfaces_ip returning nothing when interface...

### DIFF
--- a/napalm_srl/srl.py
+++ b/napalm_srl/srl.py
@@ -1174,39 +1174,41 @@ class NokiaSRLDriver(NetworkDriver):
                                 if ipv4:
                                     ipv4 = eval(ipv4.replace("'", '"'))
                                     ipv4_address_list = self._find_txt(ipv4, "address")
-                                    ipv4_address_list = list(eval(ipv4_address_list))
-                                    for dictionary_1 in ipv4_address_list:
-                                        ip_address_with_prefix = self._find_txt(
-                                            dictionary_1, "ip-prefix"
-                                        )
-                                        if ip_address_with_prefix:
-                                            ip_address = ip_address_with_prefix.split("/")
-                                            interfaces_ip[sub_interface_name]["ipv4"] = {
-                                                ip_address[0]: {
-                                                    "prefix_length": convert(
-                                                        int, ip_address[1], default="N/A"
-                                                    )
+                                    if len(ipv4_address_list) != 0:
+                                        ipv4_address_list = list(eval(ipv4_address_list))
+                                        for dictionary_1 in ipv4_address_list:
+                                            ip_address_with_prefix = self._find_txt(
+                                                dictionary_1, "ip-prefix"
+                                            )
+                                            if ip_address_with_prefix:
+                                                ip_address = ip_address_with_prefix.split("/")
+                                                interfaces_ip[sub_interface_name]["ipv4"] = {
+                                                    ip_address[0]: {
+                                                        "prefix_length": convert(
+                                                            int, ip_address[1], default="N/A"
+                                                        )
+                                                    }
                                                 }
-                                            }
 
                                 ipv6 = self._find_txt(dictionary, "ipv6")
                                 if ipv6:
                                     ipv6 = eval(ipv6.replace("'", '"'))
                                     ipv6_address_list = self._find_txt(ipv6, "address")
-                                    ipv6_address_list = list(eval(ipv6_address_list))
-                                    for dictionary_1 in ipv6_address_list:
-                                        ip_address_with_prefix = self._find_txt(
-                                            dictionary_1, "ip-prefix"
-                                        )
-                                        if ip_address_with_prefix:
-                                            ip_address = ip_address_with_prefix.split("/")
-                                            interfaces_ip[sub_interface_name]["ipv6"] = {
-                                                ip_address[0]: {
-                                                    "prefix_length": convert(
-                                                        int, ip_address[1], default="N/A"
-                                                    )
+                                    if len(ipv6_address_list) != 0:
+                                        ipv6_address_list = list(eval(ipv6_address_list))
+                                        for dictionary_1 in ipv6_address_list:
+                                            ip_address_with_prefix = self._find_txt(
+                                                dictionary_1, "ip-prefix"
+                                            )
+                                            if ip_address_with_prefix:
+                                                ip_address = ip_address_with_prefix.split("/")
+                                                interfaces_ip[sub_interface_name]["ipv6"] = {
+                                                    ip_address[0]: {
+                                                        "prefix_length": convert(
+                                                            int, ip_address[1], default="N/A"
+                                                        )
+                                                    }
                                                 }
-                                            }
 
             return interfaces_ip
         except Exception as e:

--- a/test/ci/get_interfaces_ip.py
+++ b/test/ci/get_interfaces_ip.py
@@ -1,0 +1,35 @@
+#!/usr/bin/python3
+
+import sys
+from napalm import get_network_driver
+
+import logging
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+
+driver = get_network_driver("srl")
+optional_args = {
+    "gnmi_port": 57400,
+    "jsonrpc_port": 443,
+    "insecure": True,
+    "encoding": "JSON_IETF"
+}
+
+device = driver("clab-napalm-ci_cd-srl", "admin", "NokiaSrl1!", 10, optional_args)
+
+device.open()
+
+# Add system0 interface with subinterface 0 and no ip addresses
+cfg = """
+set / interface system0
+set / interface system0 admin-state enable
+set / interface system0 subinterface 0
+"""
+
+device.load_merge_candidate(config=cfg)
+device.commit_config()
+
+# get_interfaces_ip() should not fail when no ip addresses are present
+ip_addresses = device.get_interfaces_ip()
+
+assert(ip_addresses.get("system0.0") == {})
+assert(ip_addresses is not None)


### PR DESCRIPTION
… doesn't have ip addresses configured.

Ran into an issue where I have the following interface on SR Linux:

```
--{ running }--[  ]--
A:leaf1# info interface system0 
    interface system0 {
        admin-state enable
        subinterface 0 {
        }
    }
```
Code finds the following for the interface:
```
{
  'name': 'system0',
  'subinterface': [
    {
      'index': 0,
      'admin-state': 'enable',
      'name': 'system0.0',
      'ifindex': 1086324737,
      'oper-state': 'down',
      'oper-down-reason': 'no-ip-config',
      'last-change': '2023-09-01T08:37:24.724Z',
      'ipv4': {
        'admin-state': 'disable',
        'allow-directed-broadcast': False,
        'srl_nokia-interfaces-nbr:arp': {
          'duplicate-address-detection': True,
          'timeout': 14400,
          'learn-unsolicited': False,
          'proxy-arp': False
        }
      },
      'ipv6': {
        'admin-state': 'disable',
        'srl_nokia-interfaces-nbr:neighbor-discovery': {
          'duplicate-address-detection': True,
          'reachable-time': 30,
          'stale-time': 14400,
          'learn-unsolicited': 'none',
          'proxy-nd': False
        },
        'srl_nokia-interfaces-router-adv:router-advertisement': {
          'router-role': {
            'admin-state': 'disable',
            'current-hop-limit': 64,
            'managed-configuration-flag': False,
            'other-configuration-flag': False,
            'max-advertisement-interval': 600,
            'min-advertisement-interval': 200,
            'reachable-time': 0,
            'retransmit-time': 0,
            'router-lifetime': 1800
          }
        }
      },
      'srl_nokia-qos:qos': {
        'input': {
          'classifiers': {
            'default-forwarding-class': 'fc0',
            'default-drop-probability': 'low',
            'dscp-policy': 'default',
            'dot1p-policy': 'default'
          },
          'srl_nokia-acl-policers:policer-templates': {}
        },
        'output': {
          'rewrite-rules': {
            'dscp-policy': 'default',
            'dot1p-policy': 'default'
          }
        }
      }
    }
  ]
}
```
`get_interfaces_ip()` returns `None` due to Exception when calling `list(eval(ipv4_address_list))` when that is `''` as returned by `ipv4_address_list = self._find_txt(ipv4, "address")`
The Exception is: `Error occurred : invalid syntax (<string>, line 0)`

Probably the better fix would be for `_find_txt()` to return something to denote that match was not found, but that likely would entail more fixes elsewhere in the code.

With my proposed fix I got this working for my use case.