### PR TITLE
Cleanup jsonrpc security settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,10 @@ help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 deploy-clab-ci: ## Deploy "ci" test topology
-	cd .clab && sudo clab deploy -t ci-topology.yml
+	cd .clab && sudo clab deploy -t ci-topology.yml --reconfigure
 
 destroy-clab-ci: ## Destroy "ci" test topology
-	cd .clab && sudo clab destroy -t ci-topology.yml
+	cd .clab && sudo clab destroy -t ci-topology.yml --cleanup
 
 run-tests: $(TESTS) ## Run all CI tests under test/ci
 	PYTHONPATH="." python3 $<

--- a/napalm_srl/srl.py
+++ b/napalm_srl/srl.py
@@ -2590,7 +2590,7 @@ class SRLAPI(object):
             "Content-Type": "application/json",
             "Accept": "application/json",
         }
-        proto = "https" if not self.insecure else "http"
+        proto = "https" if (self.jsonrpc_port==443 or not self.insecure) else "http"
         geturl = f"{proto}://{self.username}:{self.password}@{self.hostname}:{self.jsonrpc_port}/jsonrpc"
         cert = ( self.tls_cert, self.tls_key ) if self.tls_cert and self.tls_key else None
         resp = self.jsonrpc_session.post(geturl, headers=headers, json=json_data,

--- a/napalm_srl/srl.py
+++ b/napalm_srl/srl.py
@@ -2441,6 +2441,21 @@ class SRLAPI(object):
         self.jsonrpc_session = requests.session()
         self.jsonrpc_session.mount("https://", TLSHttpAdapter(ciphers=ciphers))
 
+        # Warn about incompatible settings
+        if self.jsonrpc_port == 443:
+            if self.insecure:
+                logging.warning( "Incompatible settings: insecure JSON RPC uses port 80, not 443" )
+        elif self.jsonrpc_port == 80:
+            if not self.insecure:
+                logging.warning( "Incompatible settings: secure JSON RPC uses port 443, not 80" )
+        else:
+            logging.warning( f"Unknown JSON RPC port configured ({self.jsonrpc_port}), only 443(default) or 80 are supported" )
+
+        if not self.insecure:
+            if not self.skip_verify and not (self.tls_cert and self.tls_key and self.tls_ca):
+                logging.warning( "Incompatible settings: secure JSON RPC with skip_verify=False " + 
+                                 "requires certificate parameters 'tls_cert','tls_key' and 'tls_ca' to be set" )
+
     def open(self):
         """Implement the NAPALM method open (mandatory)"""
         try:
@@ -2575,11 +2590,13 @@ class SRLAPI(object):
             "Content-Type": "application/json",
             "Accept": "application/json",
         }
-        geturl = "https://{}:{}@{}:{}/jsonrpc".format(self.username,
-                  self.password, self.hostname, self.jsonrpc_port)
+        proto = "https" if not self.insecure else "http"
+        geturl = f"{proto}://{self.username}:{self.password}@{self.hostname}:{self.jsonrpc_port}/jsonrpc"
+        cert = ( self.tls_cert, self.tls_key ) if self.tls_cert and self.tls_key else None
         resp = self.jsonrpc_session.post(geturl, headers=headers, json=json_data,
                                    timeout=timeout if timeout else self.timeout,
-                                   verify=self.tls_ca or False)
+                                   cert=cert,
+                                   verify=False if self.skip_verify else self.tls_ca)
         resp.raise_for_status()
         return resp.json() if resp.text else ""
 


### PR DESCRIPTION
The JSON RPC port on SR Linux is configurable, default 443 for secure https and 80 for http

This PR adds some warnings around sensible parameter settings