### PR TITLE
open tmp_cfgfil with w+ and fix seek

### DIFF
--- a/napalm_srl/srl.py
+++ b/napalm_srl/srl.py
@@ -2295,7 +2295,6 @@ class NokiaSRLDriver(NetworkDriver):
       logging.info( f"Checkpoint 'NAPALM-{self.chkpoint_id}' created: {result}" )
 
       if self._is_commit_pending():
-        print("pending commit")
         try:
           self.tmp_cfgfile.seek(0)
           json_config = json.load(self.tmp_cfgfile)

--- a/napalm_srl/srl.py
+++ b/napalm_srl/srl.py
@@ -2264,7 +2264,7 @@ class NokiaSRLDriver(NetworkDriver):
         else:
           cfg = { 'replaces' if is_replace else 'updates': [ { 'path': '/', 'value': cfg } ] }
 
-        self.tmp_cfgfile = tempfile.TemporaryFile(mode='w')
+        self.tmp_cfgfile = tempfile.TemporaryFile(mode='w+')
         json.dump(cfg, self.tmp_cfgfile, sort_keys=True)
         self.tmp_cfgfile.seek(0) # Prepare for reading back
         return "JSON candidate config loaded for " + ("replace" if is_replace else "merge")
@@ -2295,7 +2295,9 @@ class NokiaSRLDriver(NetworkDriver):
       logging.info( f"Checkpoint 'NAPALM-{self.chkpoint_id}' created: {result}" )
 
       if self._is_commit_pending():
+        print("pending commit")
         try:
+          self.tmp_cfgfile.seek(0)
           json_config = json.load(self.tmp_cfgfile)
           if message:
             raise NotImplementedError("'message' not supported with JSON config")
@@ -2311,6 +2313,7 @@ class NokiaSRLDriver(NetworkDriver):
           logging.error(e)
           raise CommitError(e) from e
       else:
+        print("no commit pending")
         return self._cli_commit(message,revert_in)
 
     def discard_config(self):
@@ -2884,3 +2887,4 @@ class SRLAPI(object):
                 if isinstance(aDict[key], dict):
                     aDict[key] = self._dictToList(aDict[key])
         return aDict
+

--- a/napalm_srl/srl.py
+++ b/napalm_srl/srl.py
@@ -2312,7 +2312,6 @@ class NokiaSRLDriver(NetworkDriver):
           logging.error(e)
           raise CommitError(e) from e
       else:
-        print("no commit pending")
         return self._cli_commit(message,revert_in)
 
     def discard_config(self):


### PR DESCRIPTION
my environment:
python: 3.10.14
napalm: 5.0.0
napalm-srl: 1.0.5

Was testing basic config changes using this simple script:

```
from napalm import get_network_driver
import json
driver = get_network_driver("srl")
optional_args = {"gnmi_port": 6030,"skip_verify": True, "insecure": True,"encoding": "JSON_IETF"}
router = driver(hostname="mydevice",username="admin",password="xxxx",optional_args=optional_args)
router.open()
config = {
  "interface": [
    {
      "name": "ethernet-1/4/1",
      "admin-state": "enable",
      "vlan-tagging": True,
      "transceiver": {
        "forward-error-correction": "base-r"
      },
      "subinterface": [
        {
          "index": 0,
          "type": "bridged",
          "vlan": {
            "encap": {
              "untagged": {
              }
            }
          }
        }
      ]
    }
  ]
}

test = json.dumps(config)


print("trying to merge")
router.load_merge_candidate(config=test)
print("compare")
diff = router.compare_config()
print(f"diff is {diff}")
input("do you want to commit? ")
router.commit_config()
print("commit")
router.close()
```
Which results in these error:
```
ERROR:root:Error occurred in compare_config: not readable
Traceback (most recent call last):
  File "/Users/lsalvatore/git/napalm-srlinux/napalm_srl/srl.py", line 2187, in compare_config
    cand_config = json.load(self.tmp_cfgfile)
  File "/opt/homebrew/Cellar/python@3.10/3.10.14/Frameworks/Python.framework/Versions/3.10/lib/python3.10/json/__init__.py", line 293, in load
    return loads(fp.read(),
io.UnsupportedOperation: not readable

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/lsalvatore/git/network-automation/utilities/srl-napalm.py", line 38, in <module>
    diff = router.compare_config()
  File "/Users/lsalvatore/git/napalm-srlinux/napalm_srl/srl.py", line 2194, in compare_config
    raise CommandErrorException(e) from e
napalm.base.exceptions.CommandErrorException: not readable
```

i was able to fix this by opening tmp_cfgfile with `w+` permissions

Also ran into a problem when doing the `compare_config()` before a commit.  When that happens we need to reset the pointer back to the start of `tmp_cfgfile` so it can be read again, so thats what line 2299 is doing

Maybe better ways of solving this but it seems to work fine for me



