### PR TITLE
Fix for handcoded timeout values in SRLAPI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
       max-parallel: 5
       matrix:
         # Python Version Updated in line with napalm project.
-        python-version: ["3.9", "3.10", "3.11", "3.12", ""]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,8 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"] # in line with Napalm base project
+        # Python Version Updated in line with napalm project.
+        python-version: ["3.9", "3.10", "3.11", "3.12", ""]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/napalm_srl/srl.py
+++ b/napalm_srl/srl.py
@@ -18,7 +18,7 @@
 Napalm driver for SR Linux.
 
 Read https://napalm.readthedocs.io for more information.
-""" 
+"""
 import base64
 import json
 import logging
@@ -2458,7 +2458,7 @@ class SRLAPI(object):
 
         if not self.insecure:
             if not self.tls_ca:
-                logging.warning( "Incompatible settings: insecure=False " + 
+                logging.warning( "Incompatible settings: insecure=False " +
                                  "requires certificate parameter 'tls_ca' to be set " +
                                  "when using self-signed certificates" )
 

--- a/napalm_srl/srl.py
+++ b/napalm_srl/srl.py
@@ -89,7 +89,7 @@ class NokiaSRLDriver(NetworkDriver):
         self._channel = None
         self.running_format = optional_args.get("running_format","json") if optional_args else "json"
 
-        self.device = SRLAPI(hostname, username, password, timeout=60, optional_args=optional_args)
+        self.device = SRLAPI(hostname, username, password, timeout=timeout, optional_args=optional_args)
 
         self.pending_commit = False
         # Whether to save changes to startup config, default False


### PR DESCRIPTION
Fix issue #62 . Timeout value passed to `SRLAPI` changed to the value passed via  `NokiaSRLDriver.__init__`
