### PR TITLE
Validate merges against the full accumulated candidate

### DIFF
--- a/docs/guide/config-management.md
+++ b/docs/guide/config-management.md
@@ -99,11 +99,11 @@ set / system banner login-banner "managed by NAPALM"
 
 ///
 
-JSON candidates are validated on the device at load time, so a malformed change fails in `load_*_candidate()` rather than in `commit_config()`. CLI candidates are validated when they are diffed or committed.
+JSON candidates are validated on the device at load time, so a malformed change fails in `load_*_candidate()` rather than in `commit_config()`. A merge onto a pending candidate validates the full accumulated candidate - exactly what `commit_config()` would send - so a merge may reference config staged by an earlier load. CLI candidates are validated when they are diffed or committed.
 
 /// note
 
-Consecutive loads accumulate into one candidate: a `load_merge_candidate()` layers onto whatever is already pending, while a `load_replace_candidate()` starts a fresh baseline (discarding any prior accumulation). Mixing CLI and JSON formats in the same candidate is rejected - `discard_config()` first.
+Consecutive loads accumulate into one candidate: a `load_merge_candidate()` layers onto whatever is already pending, while a `load_replace_candidate()` starts a fresh baseline (discarding any prior accumulation). A `load_merge_candidate()` in a different format (CLI vs JSON) than the pending candidate is rejected - `discard_config()` first. A `load_replace_candidate()` may use any format, since it starts fresh.
 
 ///
 

--- a/napalm_srlinux/srlinux.py
+++ b/napalm_srlinux/srlinux.py
@@ -1295,6 +1295,9 @@ class NokiaSRLinuxDriver(NetworkDriver):
         """
         Accepts either a native JSON formatted config, a gNMI-style JSON config
         containing only 'replaces', or SR Linux CLI commands.
+
+        Starts a fresh candidate: any previously loaded (not yet committed)
+        candidate is discarded, as a replace is a new configuration baseline.
         """
         try:
             self._load_candidate(filename, config, is_replace=True)
@@ -1310,6 +1313,10 @@ class NokiaSRLinuxDriver(NetworkDriver):
         Accepts either a native JSON formatted config (interpreted as 'update /'),
         a gNMI-style JSON config containing any number of 'deletes', 'replaces'
         and 'updates', or SR Linux CLI commands.
+
+        Merges onto any candidate already loaded in this session: consecutive
+        loads accumulate and are committed as one transaction. The merged
+        config must use the same format (JSON or CLI) as the pending candidate.
         """
         try:
             self._load_candidate(filename, config, is_replace=False)
@@ -1329,32 +1336,43 @@ class NokiaSRLinuxDriver(NetworkDriver):
         if not config:
             raise exception("Either 'filename' or 'config' argument must be provided")
 
-        # Parse and validate the new change before touching self._candidate, so a
-        # failed second load leaves any previously loaded candidate intact.
-        fragment = self._build_candidate_fragment(config, is_replace, exception)
+        # Parse the new change before touching self._candidate, so a failed
+        # second load leaves any previously loaded candidate intact.
+        fragment = self._parse_candidate_fragment(config, is_replace, exception)
 
         # load_replace starts a fresh candidate (a replace is a new baseline,
         # as with EOS 'rollback clean-config' and Junos 'overwrite'); load_merge
         # accumulates onto any candidate already loaded in this session.
-        if is_replace or self._candidate is None:
-            self._candidate = fragment
-            return
+        merging = not is_replace and self._candidate is not None
 
-        if self._candidate["mode"] != fragment["mode"]:
+        if merging and self._candidate["mode"] != fragment["mode"]:
             raise exception(
                 f"cannot merge {fragment['mode']} config into a pending "
                 f"{self._candidate['mode']} candidate; discard it first"
             )
+
         if fragment["mode"] == "json":
+            # Validate what commit_config would send: the accumulated commands,
+            # not the fragment alone — a merge may reference config that only
+            # exists in an earlier staged load. CLI candidates are validated
+            # when they are diffed or committed.
+            commands = (self._candidate["commands"] if merging else []) + fragment["commands"]
+            try:
+                self.device.validate_paths(commands)
+            except CommandErrorException as exc:
+                raise exception(f"Candidate config failed validation: {exc}") from exc
+
+        if not merging:
+            self._candidate = fragment
+        elif fragment["mode"] == "json":
             self._candidate["commands"] += fragment["commands"]
         else:
             self._candidate["lines"] += fragment["lines"]
 
-    def _build_candidate_fragment(self, config, is_replace: bool, exception) -> dict:
-        """Parse a config string into a candidate fragment without mutating state.
+    def _parse_candidate_fragment(self, config, is_replace: bool, exception) -> dict:
+        """Parse a config string into a candidate fragment.
 
-        JSON fragments are validated on the device at this point; CLI fragments
-        are validated when they are diffed or committed.
+        Does not mutate driver state and does not touch the device.
         """
         try:
             cfg = json.loads(config)
@@ -1389,12 +1407,6 @@ class NokiaSRLinuxDriver(NetworkDriver):
         else:
             action = RPCAction.REPLACE if is_replace else RPCAction.UPDATE
             commands = [{"action": action.value, "path": "/", "value": cfg}]
-
-        # validate on the device without applying
-        try:
-            self.device.validate_paths(commands)
-        except CommandErrorException as exc:
-            raise exception(f"Candidate config failed validation: {exc}") from exc
 
         return {"mode": "json", "replace": is_replace, "commands": commands}
 

--- a/test/unit/test_config_workflow.py
+++ b/test/unit/test_config_workflow.py
@@ -137,8 +137,10 @@ class TestLoadCandidate:
             {"action": "update", "path": "/", "value": json.loads(JSON_CONFIG)},
             {"action": "update", "path": "/", "value": json.loads(JSON_CONFIG_2)},
         ]
-        # each load validated its own fragment on the device
+        # the second load re-validates the full accumulated candidate, i.e.
+        # exactly what commit_config would send
         assert [c[0] for c in driver.device.calls] == ["validate", "validate"]
+        assert driver.device.calls[1][1] == driver._candidate["commands"]
 
     def test_merge_then_merge_cli_accumulates(self, driver):
         driver.load_merge_candidate(config=CLI_CONFIG)
@@ -148,12 +150,31 @@ class TestLoadCandidate:
         # CLI candidates never touch the device on load
         assert driver.device.calls == []
 
+    def test_merge_validates_combined_candidate(self, driver):
+        # a merge may depend on config staged by the replace baseline, so the
+        # merge-time validation must carry the baseline as well
+        driver.load_replace_candidate(config=JSON_CONFIG)
+        driver.load_merge_candidate(config=JSON_CONFIG_2)
+        validates = [c for c in driver.device.calls if c[0] == "validate"]
+        assert validates[-1][1] == [
+            {"action": "replace", "path": "/", "value": json.loads(JSON_CONFIG)},
+            {"action": "update", "path": "/", "value": json.loads(JSON_CONFIG_2)},
+        ]
+
     def test_replace_after_merge_resets(self, driver):
         driver.load_merge_candidate(config=JSON_CONFIG)
         driver.load_replace_candidate(config=JSON_CONFIG_2)
         assert driver._candidate["commands"] == [
             {"action": "replace", "path": "/", "value": json.loads(JSON_CONFIG_2)}
         ]
+        assert driver._candidate["replace"] is True
+
+    def test_replace_resets_across_formats(self, driver):
+        # a replace may use a different format than the pending candidate,
+        # since it discards it and starts fresh
+        driver.load_merge_candidate(config=CLI_CONFIG)
+        driver.load_replace_candidate(config=JSON_CONFIG)
+        assert driver._candidate["mode"] == "json"
         assert driver._candidate["replace"] is True
 
     def test_merge_cli_into_json_candidate_raises(self, driver):
@@ -168,6 +189,9 @@ class TestLoadCandidate:
         with pytest.raises(MergeConfigException, match="discard"):
             driver.load_merge_candidate(config=JSON_CONFIG)
         assert driver._candidate["mode"] == "cli"
+        # the format mismatch is detected before the fragment is validated,
+        # so the failed load makes no device call
+        assert driver.device.calls == []
 
     def test_failed_validation_on_second_load_keeps_first(self, driver):
         driver.load_merge_candidate(config=JSON_CONFIG)


### PR DESCRIPTION
A merge loaded on top of a pending candidate now validates the combined command list on the device - exactly what commit_config would send - so a merge may reference config staged by an earlier load. Fragment parsing is split from validation, and the format mismatch check runs before any device call, so a rejected mixed-format merge no longer spends a validate RPC. A replace may use a different format than the pending candidate, since it discards it and starts fresh.