### PR TITLE
Fix compare_config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,8 @@ deploy-clab-record: ## Deploy the two-node fixture-recording topology (SRL_VERSI
 destroy-clab-record: ## Destroy the fixture-recording topology
 	cd .clab && sudo clab destroy -t record-topology.yml --cleanup
 
-run-tests: $(TESTS) ## Run all CI tests under test/ci (needs the "ci" topology)
-	for test in $(TESTS); do \
-		uv run $$test || exit 1; \
-	done
+run-tests: ## Run all CI tests under test/ci (needs the "ci" topology)
+	uv run pytest $(TESTS)
 
 record-fixtures: ## Re-record unit test fixtures (needs the recording topology)
 	uv run tools/record_fixtures.py --prepare

--- a/README.md
+++ b/README.md
@@ -18,18 +18,19 @@ uv run ruff check napalm_srlinux test tools examples
 
 ```bash
 make deploy-clab-ci      # single-node containerlab topology
-make run-tests           # runs all test/ci scripts against it
+make run-tests           # runs all test/ci tests against it
 make destroy-clab-ci
 ```
 
-Some `test/ci` tests are written as pytest modules (e.g. `test/ci/compare_config.py`), so you can run one directly against the running topology for clean, per-test results:
+All `test/ci` tests are pytest modules, so `make run-tests` runs them in a single session with a clean, per-test summary. To run one file (or a single test) against the running topology:
 
 ```bash
-uv run pytest test/ci/compare_config.py                        # clean summary
-uv run pytest test/ci/compare_config.py --log-cli-level=DEBUG  # verbose JSON-RPC logs
+uv run pytest test/ci/compare_config.py                          # one file
+uv run pytest test/ci/compare_config.py::test_cli_candidate_diff # one test
+uv run pytest test/ci/compare_config.py --log-cli-level=DEBUG    # verbose JSON-RPC logs
 ```
 
-Logs (including the httpx/httpcore request traffic) are hidden by default and only shown on failure or when you pass `--log-cli-level`. These pytest modules also run as plain scripts (`uv run test/ci/compare_config.py`), which is how `make run-tests` invokes them.
+Logs (including the httpx/httpcore request traffic) are hidden by default and only shown on failure or when you pass `--log-cli-level`. Each file also runs as a plain script (`uv run test/ci/compare_config.py`).
 
 ### Re-recording the unit-test fixtures
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ make run-tests           # runs all test/ci scripts against it
 make destroy-clab-ci
 ```
 
+Some `test/ci` tests are written as pytest modules (e.g. `test/ci/compare_config.py`), so you can run one directly against the running topology for clean, per-test results:
+
+```bash
+uv run pytest test/ci/compare_config.py                        # clean summary
+uv run pytest test/ci/compare_config.py --log-cli-level=DEBUG  # verbose JSON-RPC logs
+```
+
+Logs (including the httpx/httpcore request traffic) are hidden by default and only shown on failure or when you pass `--log-cli-level`. These pytest modules also run as plain scripts (`uv run test/ci/compare_config.py`), which is how `make run-tests` invokes them.
+
 ### Re-recording the unit-test fixtures
 
 The mocked-data fixtures under `test/unit/mocked_data/` are verbatim JSON-RPC responses recorded from a real two-node lab (BGP, LLDP, ARP, mac-vrf, NTP, ...):

--- a/docs/development.md
+++ b/docs/development.md
@@ -18,11 +18,11 @@ uv run pytest test/unit
 
 ## Testing against a real node
 
-The `test/ci` scripts exercise the driver end-to-end against a live SR Linux container in a [containerlab](https://containerlab.dev) topology:
+The `test/ci` tests exercise the driver end-to-end against a live SR Linux container in a [containerlab](https://containerlab.dev) topology. They are pytest modules, so `make run-tests` runs them in a single session with a clean, per-test summary:
 
 ```bash
 make deploy-clab-ci      # single-node containerlab topology
-make run-tests           # runs all test/ci scripts against it
+make run-tests           # runs all test/ci tests against it
 make destroy-clab-ci
 ```
 
@@ -32,7 +32,17 @@ make destroy-clab-ci
 make deploy-clab-ci SRL_VERSION=25.10
 ```
 
-CI runs the same scripts against multiple SR Linux releases on every pull request.
+With the topology up, run a single file or test directly. Logs (including the httpx/httpcore request traffic) are hidden by default and only shown on failure or when you pass `--log-cli-level`:
+
+```bash
+uv run pytest test/ci/compare_config.py                          # one file
+uv run pytest test/ci/compare_config.py::test_cli_candidate_diff # one test
+uv run pytest test/ci/compare_config.py --log-cli-level=DEBUG    # verbose JSON-RPC logs
+```
+
+Each file also runs as a plain script (`uv run test/ci/compare_config.py`).
+
+CI runs the same tests against multiple SR Linux releases on every pull request.
 
 ## Re-recording the unit-test fixtures
 

--- a/napalm_srlinux/srlinux.py
+++ b/napalm_srlinux/srlinux.py
@@ -1427,8 +1427,9 @@ class NokiaSRLinuxDriver(NetworkDriver):
         # CLI mode: load the commands into a throwaway named candidate on the
         # device, diff it against running and discard it again. The named
         # candidate persists across JSON-RPC requests, so it is reset before and
-        # discarded after; the cli method aggregates each request's output into
-        # one blob, which for the middle request is exactly the diff text.
+        # discarded after; run_cli_commands returns one result per command
+        # string, aligned by position, so the diff text is the last result
+        # (the "diff" command is always appended last).
         enter = f"enter candidate private name {self._candidate_name}-diff"
         self._discard_named_candidate(enter)
         try:
@@ -1441,7 +1442,7 @@ class NokiaSRLinuxDriver(NetworkDriver):
         finally:
             self._discard_named_candidate(enter)
 
-        diff_result = results[0] if results else ""
+        diff_result = results[-1] if results else ""
         return (
             diff_result.get("text", "") if isinstance(diff_result, dict) else str(diff_result)
         ).strip()

--- a/test/ci/commit_confirm.py
+++ b/test/ci/commit_confirm.py
@@ -1,108 +1,113 @@
 #!/usr/bin/python3
 
-# End-to-end test of the commit-confirm workflow: commit_config(revert_in=...),
-# has_pending_commit, confirm_commit, rollback-while-pending and the automatic
-# revert when the timer expires. Exercises both the JSON candidate mode
-# (JSON-RPC confirm-timeout) and the CLI candidate mode (commit confirmed).
+"""End-to-end test of the commit-confirm workflow: commit_config(revert_in=...),
+has_pending_commit, confirm_commit, rollback-while-pending and the automatic
+revert when the timer expires. Exercises both the JSON candidate mode
+(JSON-RPC confirm-timeout) and the CLI candidate mode (commit confirmed).
+
+Run via pytest (clean output) or as a plain script (used by `make run-tests`):
+
+    uv run pytest test/ci/commit_confirm.py
+    uv run test/ci/commit_confirm.py
+"""
 
 import json
-import logging
-import sys
 import time
 
+import pytest
 from napalm import get_network_driver
 from napalm.base.exceptions import CommitError
 
-logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
-
-driver = get_network_driver("srlinux")
-optional_args = {"insecure": True}
-device = driver("clab-napalm-ci_cd-srl", "admin", "NokiaSrl1!", 10, optional_args)
-device.open()
+HOST = "clab-napalm-ci_cd-srl"
 
 
-def running_description() -> str:
-    config = device.get_config(retrieve="running")
-    parsed = json.loads(config["running"])
-    return parsed["srl_nokia-interfaces:interface"][0].get("description", "")
+@pytest.fixture(scope="module")
+def device():
+    dev = get_network_driver("srlinux")(HOST, "admin", "NokiaSrl1!", 10, {"insecure": True})
+    dev.open()
+    try:
+        yield dev
+    finally:
+        dev.close()
 
 
-def merge_description(desc: str) -> None:
-    cfg = {"interface": [{"name": "ethernet-1/1", "description": desc}]}
-    device.load_merge_candidate(config=json.dumps(cfg))
+def test_commit_confirm_workflow(device):
+    def running_description() -> str:
+        parsed = json.loads(device.get_config(retrieve="running")["running"])
+        return parsed["srl_nokia-interfaces:interface"][0].get("description", "")
 
+    def merge_description(desc: str) -> None:
+        device.load_merge_candidate(
+            config=json.dumps({"interface": [{"name": "ethernet-1/1", "description": desc}]})
+        )
 
-# --- baseline: a plain commit, no confirm pending
-merge_description("commit-confirm baseline")
-device.commit_config()
-assert not device.has_pending_commit()
-assert running_description() == "commit-confirm baseline"
-
-# --- confirm_commit without a pending confirm raises
-try:
-    device.confirm_commit()
-    raise AssertionError("confirm_commit without pending confirm did not raise")
-except CommitError:
-    pass
-
-# --- JSON mode: commit with revert timer, then confirm
-merge_description("confirmed change")
-device.commit_config(revert_in=120)
-assert device.has_pending_commit()
-assert running_description() == "confirmed change"
-
-# a second commit while the confirm is pending must be refused
-merge_description("should be refused")
-try:
+    # --- baseline: a plain commit, no confirm pending
+    merge_description("commit-confirm baseline")
     device.commit_config()
-    raise AssertionError("commit_config during pending confirm did not raise")
-except CommitError:
+    assert not device.has_pending_commit()
+    assert running_description() == "commit-confirm baseline"
+
+    # --- confirm_commit without a pending confirm raises
+    with pytest.raises(CommitError):
+        device.confirm_commit()
+
+    # --- JSON mode: commit with revert timer, then confirm
+    merge_description("confirmed change")
+    device.commit_config(revert_in=120)
+    assert device.has_pending_commit()
+    assert running_description() == "confirmed change"
+
+    # a second commit while the confirm is pending must be refused
+    merge_description("should be refused")
+    with pytest.raises(CommitError):
+        device.commit_config()
     device.discard_config()
 
-device.confirm_commit()
-assert not device.has_pending_commit()
-assert running_description() == "confirmed change"
+    device.confirm_commit()
+    assert not device.has_pending_commit()
+    assert running_description() == "confirmed change"
 
-# --- JSON mode: commit with revert timer, then reject via rollback()
-merge_description("rejected change")
-device.commit_config(revert_in=120)
-assert device.has_pending_commit()
-device.rollback()
-assert not device.has_pending_commit()
-assert running_description() == "confirmed change"
+    # --- JSON mode: commit with revert timer, then reject via rollback()
+    merge_description("rejected change")
+    device.commit_config(revert_in=120)
+    assert device.has_pending_commit()
+    device.rollback()
+    assert not device.has_pending_commit()
+    assert running_description() == "confirmed change"
 
-# --- CLI mode: verifies the 'commit confirmed timeout <s>' syntax per release
-device.load_merge_candidate(
-    config='set / interface ethernet-1/1 description "cli confirmed change"'
-)
-device.commit_config(revert_in=120)
-assert device.has_pending_commit()
-device.confirm_commit()
-assert not device.has_pending_commit()
-assert running_description() == "cli confirmed change"
+    # --- CLI mode: verifies the 'commit confirmed timeout <s>' syntax per release
+    device.load_merge_candidate(
+        config='set / interface ethernet-1/1 description "cli confirmed change"'
+    )
+    device.commit_config(revert_in=120)
+    assert device.has_pending_commit()
+    device.confirm_commit()
+    assert not device.has_pending_commit()
+    assert running_description() == "cli confirmed change"
 
-# --- auto-revert: let the timer expire
-merge_description("auto-reverted change")
-device.commit_config(revert_in=20)
-assert running_description() == "auto-reverted change"
-deadline = time.time() + 90
-while device.has_pending_commit():
-    assert time.time() < deadline, "confirm timer did not expire in time"
-    time.sleep(5)
-# the revert itself can take a moment after the pending state clears
-for _ in range(12):
-    if running_description() == "cli confirmed change":
-        break
-    time.sleep(5)
-assert running_description() == "cli confirmed change"
+    # --- auto-revert: let the timer expire
+    merge_description("auto-reverted change")
+    device.commit_config(revert_in=20)
+    assert running_description() == "auto-reverted change"
+    deadline = time.time() + 90
+    while device.has_pending_commit():
+        assert time.time() < deadline, "confirm timer did not expire in time"
+        time.sleep(5)
+    # the revert itself can take a moment after the pending state clears
+    for _ in range(12):
+        if running_description() == "cli confirmed change":
+            break
+        time.sleep(5)
+    assert running_description() == "cli confirmed change"
 
-# regression: none of the above may leave the shared per-user candidate open —
-# a later 'enter candidate private' would silently reuse its stale baseline
-(candidates,) = device.device.get_paths(
-    ["/system/configuration/candidate[name=*]"], device.device.Datastore.STATE
-)
-names = [c.get("name") for c in candidates.get("candidate", [])]
-assert "private-admin" not in names, f"stale shared candidate left open: {names}"
+    # regression: none of the above may leave the shared per-user candidate open —
+    # a later 'enter candidate private' would silently reuse its stale baseline
+    (candidates,) = device.device.get_paths(
+        ["/system/configuration/candidate[name=*]"], device.device.Datastore.STATE
+    )
+    names = [c.get("name") for c in candidates.get("candidate", [])]
+    assert "private-admin" not in names, f"stale shared candidate left open: {names}"
 
-device.close()
-sys.exit(0)  # Success
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/test/ci/compare_config.py
+++ b/test/ci/compare_config.py
@@ -1,0 +1,85 @@
+#!/usr/bin/python3
+
+"""End-to-end test of compare_config() against a real SR Linux node.
+
+Asserts the diff returned by the device matches a golden diff text word-by-word
+for both the CLI and JSON candidate modes. Run it either way:
+
+    uv run pytest test/ci/compare_config.py                         # clean output
+    uv run pytest test/ci/compare_config.py --log-cli-level=DEBUG   # verbose
+    uv run test/ci/compare_config.py                               # used by `make run-tests`
+"""
+
+import json
+
+import pytest
+from napalm import get_network_driver
+
+HOST = "clab-napalm-ci_cd-srl"
+BASE_DESC = "napalm-base"
+CLI_DESC = "napalm-cli"
+JSON_DESC = "napalm-json"
+
+# Golden diffs recorded from a real SR Linux container. Compared word-by-word
+# (whitespace-insensitive), so indentation is irrelevant, but the token
+# sequence - including the '-'/'+' markers and the changed leaves - must match.
+# SR Linux does not quote single-token description values in its diff output.
+CLI_GOLDEN = f"""
+      interface ethernet-1/1 {{
+-         description {BASE_DESC}
++         description {CLI_DESC}
+      }}
+"""
+
+JSON_GOLDEN = f"""
+      interface ethernet-1/1 {{
+-         description {BASE_DESC}
++         description {JSON_DESC}
+      }}
+"""
+
+
+def assert_golden_diff(actual: str, golden: str) -> None:
+    """Assert a device diff equals the golden text, compared word by word."""
+    assert actual.split() == golden.split(), (
+        f"diff mismatch\n--- actual ---\n{actual}\n--- golden ---\n{golden}"
+    )
+
+
+@pytest.fixture(scope="module")
+def device():
+    """Open the driver, commit a deterministic baseline, roll back on teardown."""
+    dev = get_network_driver("srlinux")(HOST, "admin", "NokiaSrl1!", 30, {"insecure": True})
+    dev.open()
+    # commit_config checkpoints the pre-change state, so rollback() restores it.
+    dev.load_merge_candidate(config=f'set / interface ethernet-1/1 description "{BASE_DESC}"')
+    dev.commit_config()
+    try:
+        yield dev
+    finally:
+        dev.rollback()
+        dev.close()
+
+
+def test_cli_candidate_diff(device):
+    """CLI candidate mode: the diff is the trailing "diff" command's own result."""
+    device.load_merge_candidate(config=f'set / interface ethernet-1/1 description "{CLI_DESC}"')
+    try:
+        assert_golden_diff(device.compare_config(), CLI_GOLDEN)
+    finally:
+        device.discard_config()
+
+
+def test_json_candidate_diff(device):
+    """JSON candidate mode: the diff comes from the JSON-RPC "diff" method."""
+    device.load_merge_candidate(
+        config=json.dumps({"interface": [{"name": "ethernet-1/1", "description": JSON_DESC}]})
+    )
+    try:
+        assert_golden_diff(device.compare_config(), JSON_GOLDEN)
+    finally:
+        device.discard_config()
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/test/ci/config_replace.py
+++ b/test/ci/config_replace.py
@@ -1,56 +1,67 @@
 #!/usr/bin/python3
 
-# End-to-end test of full config replacement: get_config -> modify ->
-# load_replace_candidate -> compare -> commit -> verify -> rollback.
+"""End-to-end test of full config replacement: get_config -> modify ->
+load_replace_candidate -> compare -> commit -> verify -> rollback.
+
+Run via pytest (clean output) or as a plain script (used by `make run-tests`):
+
+    uv run pytest test/ci/config_replace.py
+    uv run test/ci/config_replace.py
+"""
 
 import json
-import logging
-import sys
 
+import pytest
 from napalm import get_network_driver
 
-logging.basicConfig(stream=sys.stdout, level=logging.INFO)
-
+HOST = "clab-napalm-ci_cd-srl"
 LOCATION = "replaced-by-napalm"
 
-driver = get_network_driver("srlinux")
-device = driver("clab-napalm-ci_cd-srl", "admin", "NokiaSrl1!", 30, {"insecure": True})
-device.open()
 
-# fetch the full running config and use a modified copy as a full replacement
-running = json.loads(device.get_config()["running"])
-information = running.setdefault("srl_nokia-system:system", {}).setdefault(
-    "srl_nokia-system-info:information", {}
-)
-location_before = information.get("location")
-information["location"] = LOCATION
+@pytest.fixture(scope="module")
+def device():
+    dev = get_network_driver("srlinux")(HOST, "admin", "NokiaSrl1!", 30, {"insecure": True})
+    dev.open()
+    try:
+        yield dev
+    finally:
+        dev.close()
 
-device.load_replace_candidate(config=json.dumps(running))
 
-# the diff of a full replace must only contain the one modified leaf
-diff = device.compare_config()
-print(f"replace diff:\n{diff}")
-assert LOCATION in diff
+def test_full_replace_round_trip(device):
+    # fetch the full running config and use a modified copy as a full replacement
+    running = json.loads(device.get_config()["running"])
+    information = running.setdefault("srl_nokia-system:system", {}).setdefault(
+        "srl_nokia-system-info:information", {}
+    )
+    location_before = information.get("location")
+    information["location"] = LOCATION
 
-device.commit_config()
+    device.load_replace_candidate(config=json.dumps(running))
 
-# the replace took effect and the node is still manageable
-after = json.loads(device.get_config()["running"])
-assert (
-    after["srl_nokia-system:system"]["srl_nokia-system-info:information"]["location"]
-    == LOCATION
-)
+    # the diff of a full replace must only contain the one modified leaf
+    diff = device.compare_config()
+    assert LOCATION in diff
 
-# rollback restores the pre-replace state
-device.rollback()
-restored = json.loads(device.get_config()["running"])
-location_restored = (
-    restored.get("srl_nokia-system:system", {})
-    .get("srl_nokia-system-info:information", {})
-    .get("location")
-)
-assert location_restored == location_before, f"{location_restored} != {location_before}"
+    device.commit_config()
 
-device.close()
-print("config replace round-trip OK")
-sys.exit(0)
+    # the replace took effect and the node is still manageable
+    after = json.loads(device.get_config()["running"])
+    assert (
+        after["srl_nokia-system:system"]["srl_nokia-system-info:information"]["location"]
+        == LOCATION
+    )
+
+    # rollback restores the pre-replace state
+    device.rollback()
+    restored = json.loads(device.get_config()["running"])
+    location_restored = (
+        restored.get("srl_nokia-system:system", {})
+        .get("srl_nokia-system-info:information", {})
+        .get("location")
+    )
+    assert location_restored == location_before, f"{location_restored} != {location_before}"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/test/ci/create_use_dedicated_user_account.py
+++ b/test/ci/create_use_dedicated_user_account.py
@@ -1,37 +1,52 @@
 #!/usr/bin/python3
 
-# Creates a dedicated 'napalm' user account and accesses it
+"""Creates a dedicated 'napalm' user account and connects with it.
 
-import json
-import sys
+Run via pytest (clean output) or as a plain script (used by `make run-tests`):
 
+    uv run pytest test/ci/create_use_dedicated_user_account.py
+    uv run test/ci/create_use_dedicated_user_account.py
+"""
+
+import pytest
 from napalm import get_network_driver
 
-driver = get_network_driver("srlinux")
-optional_args = {"insecure": True}
-device = driver("clab-napalm-ci_cd-srl", "admin", "NokiaSrl1!", 10, optional_args)
-device.open()
+HOST = "clab-napalm-ci_cd-srl"
 
-cfg = """
+USER_CONFIG = """
 set / system configuration role napalm rule / action write
 set / system aaa authorization role napalm services [ json-rpc ]
 set / system aaa authentication user napalm password "NapalmTest1!" role [ napalm ]
 """
-device.load_merge_candidate(config=cfg)  # CLI format
-device.commit_config()
 
-# get config -> check that AAA is set
-config = device.get_config()
-parsed = json.loads(config["running"])
-print(json.dumps(parsed["srl_nokia-system:system"]["srl_nokia-aaa:aaa"], indent=2))
-device.close()
 
-# Use the newly created user account
-device2 = driver("clab-napalm-ci_cd-srl", "napalm", "NapalmTest1!", 10, optional_args)
-device2.open()
-config = device2.get_config()
-parsed2 = json.loads(config["running"])
-assert parsed2
-device2.close()
+@pytest.fixture(scope="module")
+def device():
+    dev = get_network_driver("srlinux")(HOST, "admin", "NokiaSrl1!", 10, {"insecure": True})
+    dev.open()
+    try:
+        yield dev
+    finally:
+        dev.close()
 
-sys.exit(0)  # Success
+
+def test_create_and_use_dedicated_user(device):
+    device.load_merge_candidate(config=USER_CONFIG)
+    device.commit_config()
+    try:
+        # connect and read the config as the newly created user
+        napalm_user = get_network_driver("srlinux")(
+            HOST, "napalm", "NapalmTest1!", 10, {"insecure": True}
+        )
+        napalm_user.open()
+        try:
+            assert napalm_user.get_config()["running"]
+        finally:
+            napalm_user.close()
+    finally:
+        # remove the dedicated account again
+        device.rollback()
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/test/ci/get_interfaces_ip.py
+++ b/test/ci/get_interfaces_ip.py
@@ -1,34 +1,47 @@
 #!/usr/bin/python3
 
-# Regression test: get_interfaces_ip() must not fail on subinterfaces without
-# any IP addresses.
+"""Regression test: get_interfaces_ip() must not fail on subinterfaces without
+any IP addresses.
 
-import logging
-import sys
+Run via pytest (clean output) or as a plain script (used by `make run-tests`):
 
+    uv run pytest test/ci/get_interfaces_ip.py
+    uv run test/ci/get_interfaces_ip.py
+"""
+
+import pytest
 from napalm import get_network_driver
 
-logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+HOST = "clab-napalm-ci_cd-srl"
 
-driver = get_network_driver("srlinux")
-optional_args = {"insecure": True}
-
-device = driver("clab-napalm-ci_cd-srl", "admin", "NokiaSrl1!", 10, optional_args)
-device.open()
-
-# Add system0 interface with subinterface 0 and no ip addresses
-cfg = """
+# a system0 subinterface with no IP addresses configured
+NO_IP_CONFIG = """
 set / interface system0
 set / interface system0 admin-state enable
 set / interface system0 subinterface 0
 """
 
-device.load_merge_candidate(config=cfg)
-device.commit_config()
 
-# get_interfaces_ip() should not fail when no ip addresses are present
-ip_addresses = device.get_interfaces_ip()
-assert ip_addresses is not None
-assert ip_addresses.get("system0.0") == {}
+@pytest.fixture(scope="module")
+def device():
+    dev = get_network_driver("srlinux")(HOST, "admin", "NokiaSrl1!", 10, {"insecure": True})
+    dev.open()
+    try:
+        yield dev
+    finally:
+        dev.close()
 
-device.close()
+
+def test_get_interfaces_ip_without_addresses(device):
+    device.load_merge_candidate(config=NO_IP_CONFIG)
+    device.commit_config()
+    try:
+        ip_addresses = device.get_interfaces_ip()
+        assert ip_addresses is not None
+        assert ip_addresses.get("system0.0") == {}
+    finally:
+        device.rollback()
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/test/ci/get_vlans.py
+++ b/test/ci/get_vlans.py
@@ -1,21 +1,20 @@
 #!/usr/bin/python3
 
-# End-to-end test of get_vlans: configure a mac-vrf with a single-tagged
-# bridged subinterface, check the reported VLAN and roll the change back.
+"""End-to-end test of get_vlans: configure a mac-vrf with a single-tagged
+bridged subinterface, check the reported VLAN and roll the change back.
 
-import logging
-import sys
+Run via pytest (clean output) or as a plain script (used by `make run-tests`):
 
+    uv run pytest test/ci/get_vlans.py
+    uv run test/ci/get_vlans.py
+"""
+
+import pytest
 from napalm import get_network_driver
 
-logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+HOST = "clab-napalm-ci_cd-srl"
 
-driver = get_network_driver("srlinux")
-optional_args = {"insecure": True}
-device = driver("clab-napalm-ci_cd-srl", "admin", "NokiaSrl1!", 10, optional_args)
-device.open()
-
-cfg = """
+VLAN_CONFIG = """
 set / interface ethernet-1/4 admin-state enable
 set / interface ethernet-1/4 vlan-tagging true
 set / interface ethernet-1/4 subinterface 100 type bridged
@@ -25,18 +24,30 @@ set / network-instance vlantest type mac-vrf admin-state enable
 set / network-instance vlantest interface ethernet-1/4.100
 """
 
-device.load_merge_candidate(config=cfg)
-device.commit_config()
 
-vlans = device.get_vlans()
-print(vlans)
-assert 100 in vlans
-assert vlans[100]["name"] == "vlantest"
-assert "ethernet-1/4.100" in vlans[100]["interfaces"]
+@pytest.fixture(scope="module")
+def device():
+    dev = get_network_driver("srlinux")(HOST, "admin", "NokiaSrl1!", 10, {"insecure": True})
+    dev.open()
+    try:
+        yield dev
+    finally:
+        dev.close()
 
-# revert and check the VLAN is gone again
-device.rollback()
-assert 100 not in device.get_vlans()
 
-device.close()
-sys.exit(0)  # Success
+def test_get_vlans(device):
+    device.load_merge_candidate(config=VLAN_CONFIG)
+    device.commit_config()
+
+    vlans = device.get_vlans()
+    assert 100 in vlans
+    assert vlans[100]["name"] == "vlantest"
+    assert "ethernet-1/4.100" in vlans[100]["interfaces"]
+
+    # revert and check the VLAN is gone again
+    device.rollback()
+    assert 100 not in device.get_vlans()
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/test/ci/getters_smoke.py
+++ b/test/ci/getters_smoke.py
@@ -1,14 +1,18 @@
 #!/usr/bin/python3
 
-# Smoke test: call every implemented getter against a real node and assert a
-# sane, non-None result. Cheap full-parity check for the JSON-RPC driver.
+"""Smoke test: call every implemented getter against a real node and assert a
+sane, non-None result. Cheap full-parity check for the JSON-RPC driver.
 
-import logging
-import sys
+Run via pytest (clean output) or as a plain script (used by `make run-tests`):
 
+    uv run pytest test/ci/getters_smoke.py
+    uv run test/ci/getters_smoke.py
+"""
+
+import pytest
 from napalm import get_network_driver
 
-logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+HOST = "clab-napalm-ci_cd-srl"
 
 GETTERS = [
     ("is_alive", {}),
@@ -35,24 +39,22 @@ GETTERS = [
     ("get_route_to", {}),
 ]
 
-driver = get_network_driver("srlinux")
-device = driver("clab-napalm-ci_cd-srl", "admin", "NokiaSrl1!", 10, {"insecure": True})
-device.open()
 
-failures = []
-for getter, kwargs in GETTERS:
+@pytest.fixture(scope="module")
+def device():
+    dev = get_network_driver("srlinux")(HOST, "admin", "NokiaSrl1!", 10, {"insecure": True})
+    dev.open()
     try:
-        result = getattr(device, getter)(**kwargs)
-        assert result is not None, "returned None"
-        print(f"{getter}: OK")
-    except Exception as exc:  # noqa: BLE001 - report all failures at once
-        failures.append((getter, exc))
-        print(f"{getter}: FAILED: {exc}")
+        yield dev
+    finally:
+        dev.close()
 
-device.close()
 
-if failures:
-    sys.exit(f"{len(failures)} getter(s) failed: {[g for g, _ in failures]}")
+@pytest.mark.parametrize("getter,kwargs", GETTERS, ids=[g for g, _ in GETTERS])
+def test_getter_returns_non_none(device, getter, kwargs):
+    result = getattr(device, getter)(**kwargs)
+    assert result is not None
 
-print("all getters OK")
-sys.exit(0)
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/test/ci/json_rpc_certificates.py
+++ b/test/ci/json_rpc_certificates.py
@@ -1,42 +1,43 @@
 #!/usr/bin/python3
 
-# Tests JSON-RPC connections with certificates and combinations of
-# insecure/skip_verify flags.
+"""Tests JSON-RPC connections with certificates and combinations of
+insecure/skip_verify flags.
 
-import logging
+Run via pytest (clean output) or as a plain script (used by `make run-tests`):
+
+    uv run pytest test/ci/json_rpc_certificates.py
+    uv run test/ci/json_rpc_certificates.py
+"""
+
 import os
-import sys
 
+import pytest
 from napalm import get_network_driver
 
-logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+HOST = "clab-napalm-ci_cd-srl"
+
+# the lab CA is written by containerlab under the lab directory at the repo root
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+CA_CERT = os.path.join(REPO_ROOT, ".clab", "clab-napalm-ci_cd", ".tls", "ca", "ca.pem")
 
 
-def test(jsonrpc_port=None, tls_ca="", skip_verify=False, insecure=False):
-    driver = get_network_driver("srlinux")
-    optional_args = {
-        "tls_ca": tls_ca,
-        "skip_verify": skip_verify,
-        "insecure": insecure,
-    }
-    if jsonrpc_port:
-        optional_args["jsonrpc_port"] = jsonrpc_port
-    device = driver("clab-napalm-ci_cd-srl", "admin", "NokiaSrl1!", 10, optional_args)
+@pytest.mark.parametrize(
+    "optional_args",
+    [
+        pytest.param({"tls_ca": CA_CERT}, id="https-verified-against-lab-ca"),
+        pytest.param({"skip_verify": True}, id="https-certificate-not-verified"),
+        pytest.param({"insecure": True}, id="plain-http-port-80"),
+        pytest.param({"insecure": True, "jsonrpc_port": 80}, id="plain-http-explicit-port"),
+    ],
+)
+def test_jsonrpc_connection(optional_args):
+    device = get_network_driver("srlinux")(HOST, "admin", "NokiaSrl1!", 10, optional_args)
     device.open()
-    facts = device.get_facts()
-    assert facts
-    print(
-        f"jsonrpc_port={jsonrpc_port} tls_ca={tls_ca} "
-        f"skip_verify={skip_verify} insecure={insecure} -> test OK"
-    )
-    device.close()
+    try:
+        assert device.get_facts()
+    finally:
+        device.close()
 
 
-cwd = os.getcwd() + "/.clab/clab-napalm-ci_cd/.tls/"
-
-test(tls_ca=cwd + "ca/ca.pem")  # https, verified against the lab CA
-test(skip_verify=True)  # https, certificate not verified
-test(insecure=True)  # plain http on port 80
-test(insecure=True, jsonrpc_port=80)  # plain http, explicit port
-
-sys.exit(0)  # Success
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/test/ci/load_commit_rollback.py
+++ b/test/ci/load_commit_rollback.py
@@ -1,65 +1,69 @@
 #!/usr/bin/python3
 
-# End-to-end test of the candidate config workflow: CLI merge, JSON merge,
-# compare, commit and rollback.
+"""End-to-end test of the candidate config workflow: CLI merge, JSON merge,
+compare, commit and rollback.
 
-import json
-import logging
-import sys
-from datetime import datetime
+Run via pytest (clean output) or as a plain script (used by `make run-tests`):
 
-from napalm import get_network_driver
-
-logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
-
-driver = get_network_driver("srlinux")
-optional_args = {"insecure": True}
-device = driver("clab-napalm-ci_cd-srl", "admin", "NokiaSrl1!", 10, optional_args)
-device.open()
-
-now = datetime.now().strftime("%H:%M:%S")
-DESC = f"Time {now}"
-cfg = f"""
-set / interface ethernet-1/1 description "{DESC}"
+    uv run pytest test/ci/load_commit_rollback.py
+    uv run test/ci/load_commit_rollback.py
 """
 
-device.load_merge_candidate(config=cfg)  # CLI format
-diff = device.compare_config()
-print(f"CLI diff:\n{diff}")
-assert DESC in diff
-device.commit_config()
+import json
+from datetime import datetime
 
-# get config -> check that description is set
-config = device.get_config()
-parsed = json.loads(config["running"])
-print(json.dumps(parsed["srl_nokia-interfaces:interface"], indent=2))
-assert parsed["srl_nokia-interfaces:interface"][0]["description"] == DESC
+import pytest
+from napalm import get_network_driver
 
-cfg2 = {"interface": [{"name": "ethernet-1/1", "description": f"{DESC} using JSON"}]}
-device.load_merge_candidate(config=json.dumps(cfg2))  # JSON format
-diff2 = device.compare_config()
-print(f"JSON diff:\n{diff2}")
-device.commit_config()
+HOST = "clab-napalm-ci_cd-srl"
 
-# get config -> check that description is set
-config2 = device.get_config()
-parsed2 = json.loads(config2["running"])
-print(json.dumps(parsed2["srl_nokia-interfaces:interface"], indent=2))
-assert (
-    parsed2["srl_nokia-interfaces:interface"][0]["description"]
-    == cfg2["interface"][0]["description"]
-)
 
-# Revert changes in most recent commit_config
-device.rollback()
+@pytest.fixture(scope="module")
+def device():
+    dev = get_network_driver("srlinux")(HOST, "admin", "NokiaSrl1!", 10, {"insecure": True})
+    dev.open()
+    try:
+        yield dev
+    finally:
+        dev.close()
 
-config3 = device.get_config()
-parsed3 = json.loads(config3["running"])
-assert parsed3["srl_nokia-interfaces:interface"][0]["description"] == DESC
 
-device.close()
+def _running_description(device) -> str:
+    parsed = json.loads(device.get_config()["running"])
+    return parsed["srl_nokia-interfaces:interface"][0]["description"]
 
-# Regression: check that is_alive returns false after close
-assert not device.is_alive()["is_alive"]
 
-sys.exit(0)  # Success
+def test_merge_commit_rollback(device):
+    # a fresh value each run guarantees the candidate actually differs
+    desc = f"Time {datetime.now().strftime('%H:%M:%S')}"
+
+    # CLI format merge
+    device.load_merge_candidate(config=f'set / interface ethernet-1/1 description "{desc}"')
+    assert desc in device.compare_config()
+    device.commit_config()
+    assert _running_description(device) == desc
+
+    # JSON format merge on top
+    json_desc = f"{desc} using JSON"
+    device.load_merge_candidate(
+        config=json.dumps({"interface": [{"name": "ethernet-1/1", "description": json_desc}]})
+    )
+    device.compare_config()
+    device.commit_config()
+    assert _running_description(device) == json_desc
+
+    # rollback reverts the most recent commit, restoring the CLI description
+    device.rollback()
+    assert _running_description(device) == desc
+
+
+def test_is_alive_false_after_close():
+    dev = get_network_driver("srlinux")(HOST, "admin", "NokiaSrl1!", 10, {"insecure": True})
+    dev.open()
+    assert dev.is_alive()["is_alive"]
+    dev.close()
+    assert not dev.is_alive()["is_alive"]
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/test/unit/test_config_workflow.py
+++ b/test/unit/test_config_workflow.py
@@ -268,7 +268,7 @@ class TestCompareConfig:
 
     def test_cli_mode_uses_named_candidate_with_cleanup(self, driver):
         driver.load_merge_candidate(config=CLI_CONFIG)
-        driver.compare_config()
+        result = driver.compare_config()
         kinds = [c[0] for c in driver.device.calls]
         assert kinds == ["cli", "cli", "cli"]  # reset, diff, cleanup
         reset, diff, cleanup = (c[1] for c in driver.device.calls)
@@ -278,6 +278,9 @@ class TestCompareConfig:
         assert diff[-1] == "diff"
         assert CLI_CONFIG.splitlines()[0] in diff
         assert cleanup == [enter, "discard now"]
+        # the returned diff is the "diff" command's own result, not the
+        # "enter candidate ..." command's (which is always first and empty)
+        assert result == "output of diff"
 
     def test_cli_replace_mode_deletes_first(self, driver):
         driver.load_replace_candidate(config=CLI_CONFIG)

--- a/test/unit/test_config_workflow.py
+++ b/test/unit/test_config_workflow.py
@@ -61,6 +61,8 @@ class RecordingDevice:
 
     def run_cli_commands(self, commands, output_format="text"):
         self.calls.append(("cli", commands))
+        # one result per command, positionally aligned, so a test can assert
+        # compare_config reads the diff from the right position (last, not first)
         return [{"text": f"output of {c}"} for c in commands]
 
     def set_paths(self, commands, datastore=None, confirm_timeout=None):
@@ -278,8 +280,8 @@ class TestCompareConfig:
         assert diff[-1] == "diff"
         assert CLI_CONFIG.splitlines()[0] in diff
         assert cleanup == [enter, "discard now"]
-        # the returned diff is the "diff" command's own result, not the
-        # "enter candidate ..." command's (which is always first and empty)
+        # the returned diff is the "diff" command's own (last) result, not the
+        # "enter candidate ..." command's, which is always first
         assert result == "output of diff"
 
     def test_cli_replace_mode_deletes_first(self, driver):


### PR DESCRIPTION
Fix compare_config - current implementation always returns empty string for me.

When I added debug output for `results` in compare_config I've got something like
```
['', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '      interface ethernet-1/1 {\n-         description ...']
```